### PR TITLE
Add whereMany method

### DIFF
--- a/docs/Clause/WHERE.md
+++ b/docs/Clause/WHERE.md
@@ -20,6 +20,7 @@
 + `orWhereNull()`
 + `whereNotNull()`
 + `orWhereNotNull()`
++ `whereMany()`
 
 > Used in [SELECT](https://github.com/FaaPz/Slim-PDO/blob/master/docs/Statement/SELECT.md), [UPDATE](https://github.com/FaaPz/Slim-PDO/blob/master/docs/Statement/UPDATE.md) and [DELETE](https://github.com/FaaPz/Slim-PDO/blob/master/docs/Statement/DELETE.md) statements.
 
@@ -52,4 +53,7 @@ $statement->whereNull('f_name');
 
 // ... WHERE l_name IS NOT NULL
 $statement->whereNotNull('l_name');
+
+// ... WHERE col_1 = ? AND col_2 = ? AND col_3 = ?
+$statement->whereMany( array( 'col_1' => 'val_1', 'col_2' => 'val_2', 'col_3' => 'val_3' ), '=' );
 ```

--- a/src/PDO/Clause/WhereClause.php
+++ b/src/PDO/Clause/WhereClause.php
@@ -199,6 +199,18 @@ class WhereClause extends ClauseContainer
     {
         $this->whereNotNull($column, 'OR');
     }
+    
+    /**
+     * @param        $columns
+     * @param null   $operator
+     * @param string $rule
+     */
+    public function whereMany ( $columns, $operator = null, $rule = 'AND' )
+    {
+        foreach ( $columns as $column ) {
+            $this->container[] = ' ' . $rule . ' ' . $column . ' ' . $operator . ' ?';
+        }
+    }
 
     /**
      * @return string

--- a/src/PDO/Statement/StatementContainer.php
+++ b/src/PDO/Statement/StatementContainer.php
@@ -350,6 +350,22 @@ abstract class StatementContainer
     }
 
     /**
+     * @param array  $columns
+     * @param string $operator
+     * @param string $rule
+     *
+     * @return $this
+     */
+    public function whereMany( $columns, $operator = null, $rule = 'AND' )
+    {
+
+        $this->values = array_merge( $this->values, array_values( $columns ) );
+        $this->whereClause->whereMany( array_keys( $columns ), $operator, $rule );
+
+        return $this;
+    }
+
+    /**
      * @param $statement
      * @param string $order
      *


### PR DESCRIPTION
Easy shortcut which can be used instead of chaining many `where()` methods different only in column name and value.
