### PR TITLE
Provided a way to opt-opt of all options being passed to PDO.

### DIFF
--- a/src/PDO/Database.php
+++ b/src/PDO/Database.php
@@ -28,14 +28,22 @@ class Database extends \PDO
      */
     public function __construct($dsn, $usr = null, $pwd = null, array $options = array())
     {
-        $options = array(
+        $options = $this->getDefaultOptions() + $options;
+
+        @parent::__construct($dsn, $usr, $pwd, $options);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDefaultOptions()
+    {
+        return array(
             \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
             \PDO::ATTR_EMULATE_PREPARES => false,
             \PDO::ATTR_STATEMENT_CLASS => array('Slim\\PDO\\Statement', array($this)),
-        ) + $options;
-
-        @parent::__construct($dsn, $usr, $pwd, $options);
+        );
     }
 
     /**


### PR DESCRIPTION
Some drivers like FreeTDS 0.91 do no support any options making it impossible to use this library.  I would like to propose the following fix to let developers work around the default behavior for situations like this FreeTDS shortfall.
