### PR TITLE
Fixing execute return for postgres

### DIFF
--- a/src/PDO/Statement/InsertStatement.php
+++ b/src/PDO/Statement/InsertStatement.php
@@ -95,9 +95,7 @@ class InsertStatement extends StatementContainer
      */
     public function execute()
     {
-        parent::execute();
-
-        return $this->dbh->lastInsertId();
+        return parent::execute();
     }
 
     /**


### PR DESCRIPTION
"lastInsertId" doesn't work for postgresql databases so it should not be used.
