### PR TITLE
Add combination in sql WHERE Clause (closes #28)

### DIFF
--- a/src/PDO/Clause/WhereClause.php
+++ b/src/PDO/Clause/WhereClause.php
@@ -6,6 +6,8 @@
  */
 namespace Slim\PDO\Clause;
 
+use Slim\PDO\Statement\StatementCombination;
+
 /**
  * Class WhereClause.
  *
@@ -20,7 +22,14 @@ class WhereClause extends ClauseContainer
      */
     public function where($column, $operator = null, $chainType = 'AND')
     {
-        $this->container[] = ' '.$chainType.' '.$column.' '.$operator.' ?';
+        if ($column instanceof StatementCombination)
+        {
+            $this->container[] = ' '.$chainType.' '.$column;
+        }
+        else
+        {
+            $this->container[] = ' '.$chainType.' '.$column.' '.$operator.' ?';
+        }
     }
 
     /**

--- a/src/PDO/Statement/StatementCombination.php
+++ b/src/PDO/Statement/StatementCombination.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license MIT
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace Slim\PDO\Statement;
+
+class StatementCombination extends StatementContainer
+{
+    public function __toString()
+    {
+        // Remove `WHERE` prefix in whereClause string
+        $sql = substr(trim($this->whereClause), 5);
+
+        return '('.trim($sql).')';
+    }
+}

--- a/src/PDO/Statement/StatementContainer.php
+++ b/src/PDO/Statement/StatementContainer.php
@@ -82,7 +82,14 @@ abstract class StatementContainer
      */
     public function where($column, $operator = null, $value = null, $chainType = 'AND')
     {
-        $this->values[] = $value;
+        if ($column instanceof StatementCombination)
+        {
+            $this->setValues($column->values);
+        }
+        else
+        {
+            $this->values[] = $value;
+        }
 
         $this->whereClause->where($column, $operator, $chainType);
 
@@ -500,5 +507,15 @@ abstract class StatementContainer
         }
 
         return implode($separator, $result);
+    }
+
+    /**
+     * @return StatementCombination
+     */
+    public function combine()
+    {
+        $stmt = new StatementCombination($this->dbh);
+
+        return $stmt;
     }
 }


### PR DESCRIPTION
Usage: 

```
// create new StatementCombination object
$combined = $stmt->combine()->where('foo', '=', 'bar')
            ->orWhereLike('foo', 'baz')
            ->orWhereNot('foo', '=', 'qux');

// apply combination
$stmt->where($combined);

// SQL: ... WHERE (foo = bar OR foo LIKE baz OR NOT foo = qux) ...
```
