### PR TITLE
LimitClause: allow null (or ommitted) offset argument

### DIFF
--- a/src/PDO/Clause/LimitClause.php
+++ b/src/PDO/Clause/LimitClause.php
@@ -33,7 +33,7 @@ class LimitClause extends ClauseContainer
             trigger_error('Expects parameters as integers', E_USER_ERROR);
         }
 
-        if ($offset >= 0) {
+        if ($offset > 0) {
             $this->limit = intval($offset).' , '.intval($number);
         } elseif ($number >= 0) {
             $this->limit = intval($number);

--- a/src/PDO/Clause/LimitClause.php
+++ b/src/PDO/Clause/LimitClause.php
@@ -25,6 +25,10 @@ class LimitClause extends ClauseContainer
      */
     public function limit($number, $offset = null)
     {
+        if (is_null($offset)) {
+            $offset = 0;
+        }
+
         if (!is_int($number) || !is_int($offset)) {
             trigger_error('Expects parameters as integers', E_USER_ERROR);
         }


### PR DESCRIPTION
Current implementation does not allow to omit offset argument from limit(): default $offset is null, but then an is_int check follows:

```
$db->select()->from('users')->limit(1);
```

```
'Expects parameters as integers' in vendor/slim/pdo/src/PDO/Clause/LimitClause.php:29
```
