### PR TITLE
LimitClause: offset compatibility. Fixes #47

### DIFF
--- a/src/PDO/Clause/LimitClause.php
+++ b/src/PDO/Clause/LimitClause.php
@@ -30,7 +30,7 @@ class LimitClause extends ClauseContainer
         }
 
         if ($offset >= 0) {
-            $this->limit = intval($offset).' , '.intval($number);
+            $this->limit = intval($number).' OFFSET '.intval($offset);
         } elseif ($number >= 0) {
             $this->limit = intval($number);
         }


### PR DESCRIPTION
Use the de-facto standard LIMIT n OFFSET m syntax instead of MySQL-specific LIMIT n,m.

It won't solve the incorrect SQL issue when calling ->limit($num, $offset)->offset($offset), but this problem existed anyway. and doesn't seem to be solvable without reworking LimitClause and OffsetClause into a single LimitOffsetClause.
