### PR TITLE
Fix for #57 - Overwrite default options

### DIFF
--- a/src/PDO/Database.php
+++ b/src/PDO/Database.php
@@ -29,7 +29,7 @@ class Database extends \PDO
      */
     public function __construct($dsn, $usr = null, $pwd = null, array $options = array())
     {
-        $options = $this->getDefaultOptions() + $options;
+        $options = $options + $this->getDefaultOptions();
 
         @parent::__construct($dsn, $usr, $pwd, $options);
     }


### PR DESCRIPTION
It wasn't possible to overwrite any options set in Database::getDefaultOptions() when passing the $options array into the constructor.

Merging $options and $defaultOptions together now will use the values provided in the constructor if they differ from the defaults.
