### PR TITLE
stop excuting when field value is not expected

### DIFF
--- a/src/PDO/Statement/StatementContainer.php
+++ b/src/PDO/Statement/StatementContainer.php
@@ -426,9 +426,27 @@ abstract class StatementContainer
     public function execute()
     {
         $stmt = $this->getStatement();
-        $stmt->execute($this->values);
+        $this->bindValues($stmt, $this->values);
+        $stmt->execute();
 
         return $stmt;
+    }
+
+    /**
+     * Bind values to their parameters in the given statement.
+     *
+     * @param  \PDOStatement $statement
+     * @param  array  $bindings
+     * @return void
+     */
+    protected function bindValues($statement, $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            $statement->bindValue(
+                is_string($key) ? $key : $key + 1, $value,
+                is_int($value) ? \PDO::PARAM_INT : \PDO::PARAM_STR
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
fix error with value is array which field need string,so that framework can handle error before excute.

exapmle:

`._testInsert.php`
```
<?php

//handle errors
error_reporting(-1);
ini_set('display_errors', 'Off');
set_error_handler('handleError');
function handleError($errorno, $errorstr, $errorfile, $errorline)                                                                                               
{
    if (error_reporting() & $errorno) {
        throw new ErrorException($errorstr, 0, $errorno, $errorfile, $errorline);
    }
}

require_once 'vendor/autoload.php';

$pdo = new \Slim\PDO\Database('pgsql:host=127.0.0.1;port=5432;dbname=dbname', 'develop', '');

######### table: users #########
//field
//------ id int   
//------ name varchar(12)
######### end #########
$insertStatement = $pdo->insert(array('id', 'name'))
    ->into('users')
    ->values(array(123, array('your_name')));
try {
    $insertId = $insertStatement->execute(false);
    var_dump('succ:', $insertId);
} catch (\Exception $e) {
    echo 'error:', $e->getMessage();
}
```

* before fix:
  >run cmd:`php ._testInsert.php`
  >
  >result:`error:Array to string conversion`
  >***but*** the database insert successfully
  >
  >`select * from users ;`
  > | id  | name  |
  >| -- | ------ |
  >|123 | Array|

* after fix:
  >run cmd:`php ._testInsert.php`
  >
  >result:`error:Array to string conversion`
  >***and*** the database doesn't insert data.