### PR TITLE
update README composer.json error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use [Composer](https://getcomposer.org/)
 
 ```json
 "require": {
-    "slim/pdo": "~1.9"
+    "slim/pdo": "~1.10"
 }
 ```
 


### PR DESCRIPTION
composer config error
- v1.10 is release, but the README still v1.9.